### PR TITLE
fix: Fixed Apple Silicon not working with the Alpine image

### DIFF
--- a/.github/workflows/buildAndPushImage.yml
+++ b/.github/workflows/buildAndPushImage.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        env:
-          BUILDX_NO_DEFAULT_ATTESTATIONS: 1
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -47,3 +47,4 @@ jobs:
           platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ env.IMAGE_URL }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          provenance: false

--- a/.github/workflows/buildAndPushImage.yml
+++ b/.github/workflows/buildAndPushImage.yml
@@ -42,6 +42,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ env.IMAGE_URL }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/buildAndPushImage.yml
+++ b/.github/workflows/buildAndPushImage.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        env:
+          BUILDX_NO_DEFAULT_ATTESTATIONS: 1
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/buildAndPushImage.yml
+++ b/.github/workflows/buildAndPushImage.yml
@@ -42,6 +42,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ env.IMAGE_URL }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/buildAndPushImage.yml
+++ b/.github/workflows/buildAndPushImage.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'dev'
+      - 'nightly'
   pull_request:
     branches:
       - 'main'
@@ -13,7 +14,7 @@ on:
 env:
   IMAGE_URL: ghcr.io/ust-demaf
   IMAGE_NAME: ansible-mps-plugin
-  IMAGE_TAG: ${{ github.ref == 'refs/heads/main' && 'latest' || 'testing' }}
+  IMAGE_TAG: ${{ github.ref == 'refs/heads/main' && 'latest' || github.ref == 'refs/heads/dev' && 'dev' || 'nightly' }}
 
 jobs:
   build-using-dockerfile-push-2-ghcr:

--- a/.github/workflows/buildAndPushImage.yml
+++ b/.github/workflows/buildAndPushImage.yml
@@ -26,12 +26,12 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -45,7 +45,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ env.IMAGE_URL }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           provenance: false

--- a/.github/workflows/buildAndPushImage.yml
+++ b/.github/workflows/buildAndPushImage.yml
@@ -24,11 +24,24 @@ jobs:
         with:
           submodules: 'true'
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Container Registry
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u well5a --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build the Docker image
-        run: docker build . --file Dockerfile --tag $IMAGE_URL/$IMAGE_NAME:$IMAGE_TAG
-
-      - name: Push the Docker image
-        run: docker push $IMAGE_URL/$IMAGE_NAME:$IMAGE_TAG
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.IMAGE_URL }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/buildAndPushImage.yml
+++ b/.github/workflows/buildAndPushImage.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -40,7 +42,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/buildAndPushImage.yml
+++ b/.github/workflows/buildAndPushImage.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'main'
       - 'dev'
-      - 'nightly'
   pull_request:
     branches:
       - 'main'
@@ -14,7 +13,7 @@ on:
 env:
   IMAGE_URL: ghcr.io/ust-demaf
   IMAGE_NAME: ansible-mps-plugin
-  IMAGE_TAG: ${{ github.ref == 'refs/heads/main' && 'latest' || github.ref == 'refs/heads/dev' && 'dev' || 'nightly' }}
+  IMAGE_TAG: ${{ github.ref == 'refs/heads/main' && 'latest' || 'testing' }}
 
 jobs:
   build-using-dockerfile-push-2-ghcr:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY mps-transformation-ansible ./mps-transformation-ansible
 RUN mkdir -p /app/mps-transformation-ansible/transformationInput
 
 # Build the project, using multiple threads and skipping tests
-RUN mvn -T 2C clean package -DskipTests
+RUN mvn -T 2C -q clean package -DskipTests
 
 # Stage 2: Create a minimal runtime image using OpenJDK 11 JRE
 FROM openjdk:11-jre-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform linux/amd64 alpine:3.19.0
+FROM --platform=linux/amd64 alpine:3.19.0
 
 ENV GLIBC_VERSION 2.35-r1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 RUN apk upgrade --no-cache \
-    && apk add --no-cache bash curl gcompat libstdc++ maven openjdk11
+    && apk add --no-cache bash curl gcompat libc6-compat libstdc++ maven openjdk11
 
 RUN mkdir -p /app/target
 WORKDIR /app
@@ -11,6 +11,6 @@ COPY src ./src
 COPY mps-transformation-ansible ./mps-transformation-ansible
 RUN mkdir -p /app/mps-transformation-ansible/transformationInput
 
-RUN mvn clean package -DskipTests
+RUN mvn -T 1C -q clean package -DskipTests
 
 CMD java -jar target/ansible-mps-plugin-0.0.1-SNAPSHOT.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
-FROM alpine:latest
+FROM alpine:3.19.0
+
+ENV GLIBC_VERSION 2.35-r1
 
 RUN apk upgrade --no-cache \
-    && apk add --no-cache bash curl gcompat libc6-compat libstdc++ maven openjdk11
+    && apk add --no-cache bash curl libstdc++ maven openjdk11
+
+RUN curl -Lo /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+    curl -Lo glibc.apk "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk" && \
+    curl -Lo glibc-bin.apk "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk" && \
+    apk add --force-overwrite glibc-bin.apk glibc.apk && \
+    /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
+    echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
+    apk del curl && \
+    rm -rf /var/cache/apk/* glibc.apk glibc-bin.apk
 
 RUN mkdir -p /app/target
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19.0
+FROM --platform linux/amd64 alpine:3.19.0
 
 ENV GLIBC_VERSION 2.35-r1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM alpine:latest
 
 RUN apk upgrade --no-cache \
-    && apk add --no-cache bash curl git libstdc++ maven openjdk11 sudo
+    && apk add --no-cache bash curl libstdc++ maven openjdk11
     
-RUN git clone https://gitlab.com/manoel-linux1/GlibMus-HQ.git \
-    && cd GlibMus-HQ \
-    && chmod a+x compile-x86_64-alpine-linux.sh \
-    && ./compile-x86_64-alpine-linux.sh
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+    && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-2.35-r1.apk \
+    && apk add glibc-2.35-r1.apk
 
 RUN mkdir -p /app/target
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
 FROM alpine:latest
 
 RUN apk upgrade --no-cache \
-    && apk add --no-cache bash curl libstdc++ maven openjdk11
-    
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
-    && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-2.35-r1.apk \
-    && apk add glibc-2.35-r1.apk
+    && apk add --no-cache bash curl gcompat libstdc++ maven openjdk11
 
 RUN mkdir -p /app/target
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,28 @@
-FROM --platform=linux/amd64 alpine:3.19.0
+# Stage 1: Build the application using Maven with Eclipse Temurin JDK 11
+FROM maven:3.8.6-eclipse-temurin-11 AS build
 
-ENV GLIBC_VERSION 2.35-r1
-
-RUN apk upgrade --no-cache \
-    && apk add --no-cache bash curl libstdc++ maven openjdk11
-
-RUN curl -Lo /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-    curl -Lo glibc.apk "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk" && \
-    curl -Lo glibc-bin.apk "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk" && \
-    apk add --force-overwrite glibc-bin.apk glibc.apk && \
-    /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
-    apk del curl && \
-    rm -rf /var/cache/apk/* glibc.apk glibc-bin.apk
-
-RUN mkdir -p /app/target
+# Set the working directory for the build stage
 WORKDIR /app
 
+# Copy the Maven project file and source code into the container
 COPY pom.xml .
 COPY src ./src
 COPY mps-transformation-ansible ./mps-transformation-ansible
+
+# Create the necessary directory for transformation input
 RUN mkdir -p /app/mps-transformation-ansible/transformationInput
 
-RUN mvn -T 1C -q clean package -DskipTests
+# Build the project, using multiple threads and skipping tests
+RUN mvn -T 2C clean package -DskipTests
 
-CMD java -jar target/ansible-mps-plugin-0.0.1-SNAPSHOT.jar
+# Stage 2: Create a minimal runtime image using OpenJDK 11 JRE
+FROM openjdk:11-jre-slim
+
+# Set the working directory for the runtime stage
+WORKDIR /app
+
+# Copy all built files from the build stage to the runtime stage
+COPY --from=build /app /app
+
+# Set the command to run the application
+CMD ["java", "-jar", "/app/target/ansible-mps-plugin-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM alpine:latest
 
 RUN apk upgrade --no-cache \
-    && apk add --no-cache bash curl libstdc++ maven openjdk11 gcompat
+    && apk add --no-cache bash curl git libstdc++ maven openjdk11 sudo
+    
+RUN git clone https://gitlab.com/manoel-linux1/GlibMus-HQ.git \
+    && cd GlibMus-HQ \
+    && chmod a+x compile-x86_64-alpine-linux.sh \
+    && ./compile-x86_64-alpine-linux.sh
 
 RUN mkdir -p /app/target
 WORKDIR /app


### PR DESCRIPTION
Sadly, we had to drop the idea of using Alpine Linux for our images.
We are now using a separate build image and deploy image for the plugin.
For building we're using `maven:3.8.6-eclipse-temurin-11` and for the final deployed image we're using `openjdk:11-jre-slim` as base. This reduced the image size down to 363.39MB.